### PR TITLE
Forward application language to Unlayer + translate label/button

### DIFF
--- a/resources/views/unlayer.blade.php
+++ b/resources/views/unlayer.blade.php
@@ -15,6 +15,7 @@
 
         unlayer.init({
             id: 'editor',
+            locale: document.documentElement.lang,
             displayMode: 'email',
             features: {textEditor: {spellChecker: true}},
             tools: {form: {enabled: false}},
@@ -70,7 +71,7 @@
 </script>
 <div>
     <div class="form-row max-w-full h-full">
-        <label class="label" for="html">Body</label>
+        <label class="label" for="html">{{ __('Body') }}</label>
         @isset($errors)
             @error('html')
                 <p class="form-error" role="alert">{{ $message }}</p>
@@ -86,7 +87,7 @@
 
 <div class="form-buttons">
     <button id="save" type="submit" class="button">
-        <x-icon-label icon="fa-code" text="Save content"/>
+        <x-icon-label icon="fa-code" :text="__('Save content')"/>
     </button>
 </div>
 


### PR DESCRIPTION
This PR adds:

- Translations for the label & button, in preparation for https://github.com/spatie/laravel-mailcoach/pull/247
- Implements the `locale` key on the Unlayer instance. See https://docs.unlayer.com/docs/localization for reference.