### PR TITLE
Add ability to overrule unlayer options via config

### DIFF
--- a/resources/views/unlayer.blade.php
+++ b/resources/views/unlayer.blade.php
@@ -17,7 +17,7 @@
             return;
         }
 
-        unlayer.init({!! json_encode($options) !!});
+        unlayer.init(@json($options));
 
         window.unlayerInitialized = true;
 

--- a/resources/views/unlayer.blade.php
+++ b/resources/views/unlayer.blade.php
@@ -13,12 +13,7 @@
             return;
         }
 
-        unlayer.init({
-            id: 'editor',
-            displayMode: 'email',
-            features: {textEditor: {spellChecker: true}},
-            tools: {form: {enabled: false}},
-        });
+        unlayer.init({!! json_encode($options) !!});
 
         window.initialized = true;
 

--- a/src/UnlayerEditor.php
+++ b/src/UnlayerEditor.php
@@ -11,8 +11,8 @@ class UnlayerEditor implements Editor
     public function render(HasHtmlContent $model): string
     {
         $replacers = collect(config('mailcoach.replacers'))
-            ->map(fn(string $className) => app($className))
-            ->flatMap(fn(ReplacerWithHelpText $replacer) => $replacer->helpText())
+            ->map(fn (string $className) => app($className))
+            ->flatMap(fn (ReplacerWithHelpText $replacer) => $replacer->helpText())
             ->toArray();
 
         $options = array_merge_recursive([

--- a/src/UnlayerEditor.php
+++ b/src/UnlayerEditor.php
@@ -11,15 +11,23 @@ class UnlayerEditor implements Editor
     public function render(HasHtmlContent $model): string
     {
         $replacers = collect(config('mailcoach.replacers'))
-            ->map(fn (string $className) => app($className))
-            ->flatMap(fn (ReplacerWithHelpText $replacer) => $replacer->helpText())
+            ->map(fn(string $className) => app($className))
+            ->flatMap(fn(ReplacerWithHelpText $replacer) => $replacer->helpText())
             ->toArray();
+
+        $options = array_merge_recursive([
+            'id' => 'editor',
+            'displayMode' => 'email',
+            'features'=> ['textEditor' => ['spellChecker' => true]],
+            'tools'=> ['form' => ['enabled' => false]],
+        ], config('mailcoach.unlayer.options', []));
 
         return view('mailcoach-unlayer::unlayer')
             ->with([
                 'html' => old('html', $model->getHtml()),
                 'structuredHtml' => old('structured_html', $model->getStructuredHtml()),
                 'replacers' => $replacers,
+                'options' => $options,
             ])
             ->render();
     }

--- a/tests/UnlayerEditorTest.php
+++ b/tests/UnlayerEditorTest.php
@@ -19,4 +19,21 @@ class UnlayerEditorTest extends TestCase
         $this->assertStringContainsString('input type="hidden" name="html"', $html);
         $this->assertStringContainsString('input type="hidden" name="structured_html"', $html);
     }
+
+    /** @test * */
+    public function test_passes_along_configured_options()
+    {
+        config(['mailcoach.unlayer.options' => [
+            'appearance' => ['theme' => 'dark']
+        ]]);
+
+        $editor = new UnlayerEditor();
+
+        $template = factory(Template::class)->create();
+
+        $html = $editor->render($template);
+
+        $this->assertStringContainsString('appearance', $html);
+        $this->assertStringContainsString('dark', $html);
+    }
 }


### PR DESCRIPTION
For instance, we can now provide customs options like color options:

```
'unlayer' => [
    ...
    'options' => [
        'features' => [
            'colorPicker' => [
                'presets' => ['#D9E3F0', '#F47373', '#697689', '#37D67A', '#2CCCE4', '#555555', '#DCE775'],
            ],
        ],
    ],
],
```